### PR TITLE
speed up jest tests by less parallelization

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -34,15 +34,6 @@ jobs:
       - name: Run tests
         run: yarn test --maxWorkers=2
 
-      - name: Run tests
-        run: yarn test
-
-      - name: Run tests
-        run: yarn test --maxWorkers=2
-
-      - name: Run tests
-        run: yarn test --maxWorkers=1
-
       - name: Build code
         run: yarn build
 


### PR DESCRIPTION
Jest runs tests in parallel by default, but people have seen that in some projects this is not the best strategy for speed. It seems that ours is one of them. Might be that our tests need to import (and for that to transpile) a ton of SDK code. Doing that intense work in parallel threads might be the cause of slowdown.