### PR TITLE
SK-257: set extension description

### DIFF
--- a/src/static/_locales/en/messages.json
+++ b/src/static/_locales/en/messages.json
@@ -6,7 +6,7 @@
     "message": "Sporran"
   },
   "manifest_description": {
-    "message": "TODO"
+    "message": "Sporran. The wallet for your KILTs and credentials."
   },
   "common_action_back": {
     "message": "Back"


### PR DESCRIPTION
SK-257

Looking at the [documentation](https://developer.chrome.com/docs/extensions/mv2/manifest/description/) I think that the long description needs to be set through the webstore UI.