### PR TITLE
no warnings for tests

### DIFF
--- a/src/components/BalanceUpdateLink/BalanceUpdateLink.test.tsx
+++ b/src/components/BalanceUpdateLink/BalanceUpdateLink.test.tsx
@@ -12,6 +12,11 @@ import { BalanceUpdateLink } from './BalanceUpdateLink';
 
 const mockAddress = '4tJbxxKqYRv3gDvY66BKyKzZheHEH8a27VBiMfeGX2iQrire';
 
+jest.mock('@kiltprotocol/chain-helpers', () => ({
+  BlockchainApiConnection: {
+    getConnectionOrConnect: jest.fn(),
+  },
+}));
 jest.mock('../../channels/existentialDepositChannel/existentialDepositChannel');
 jest.mock('../../channels/VestingChannels/VestingChannels');
 


### PR DESCRIPTION
When the imports of @kiltprotocol/* packages are not completely mocked this way, we get warnings in tests: `@polkadot/util has multiple versions, ensure that there is only one installed.`