### PR TITLE
downgrade bn.js since polkadot still uses v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@kiltprotocol/messaging": "^0.23.0-beta.2",
     "@polkadot/extension-inject": "^0.39.1",
     "@polkadot/ui-shared": "^0.84.1",
-    "bn.js": "^5.2.0",
+    "bn.js": "^4.12.0",
     "classnames": "^2.3.1",
     "lodash-es": "^4.17.21",
     "qrcode.react": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4444,12 +4444,12 @@ bluebird@~2.9.24:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.34.tgz#2f7b4ec80216328a9fddebdf69c8d4942feff7d8"
   integrity sha1-L3tOyAIWMoqf3evfacjUlC/v99g=
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9, bn.js@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
-bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0:
+bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==


### PR DESCRIPTION
This way we include fewer copies of it in the final bundle