### PR TITLE
InjectedSigner methods accept all address encodings

### DIFF
--- a/src/utilities/identities/identities.ts
+++ b/src/utilities/identities/identities.ts
@@ -113,7 +113,7 @@ export async function removeIdentity(identity: Identity): Promise<void> {
 }
 
 // KILT has registered the ss58 prefix 38
-const ss58Format = 38;
+export const ss58Format = 38;
 
 export function makeKeyring(): Keyring {
   return new Keyring({

--- a/src/views/SignDApp/SignDApp.tsx
+++ b/src/views/SignDApp/SignDApp.tsx
@@ -1,9 +1,13 @@
 import { FormEvent, Fragment, useCallback } from 'react';
 import { browser } from 'webextension-polyfill-ts';
+import { Crypto } from '@kiltprotocol/utils';
 
 import * as styles from './SignDApp.module.css';
 
-import { useIdentities } from '../../utilities/identities/identities';
+import {
+  ss58Format,
+  useIdentities,
+} from '../../utilities/identities/identities';
 import { usePopupData } from '../../utilities/popups/usePopupData';
 import { Avatar } from '../../components/Avatar/Avatar';
 import { CopyValue } from '../../components/CopyValue/CopyValue';
@@ -25,7 +29,8 @@ export function SignDApp(): JSX.Element | null {
   const passwordField = usePasswordField();
 
   const identities = useIdentities().data;
-  const identity = identities && identities[input.address as string];
+  const kiltAddress = Crypto.encodeAddress(input.address as string, ss58Format);
+  const identity = identities && identities[kiltAddress];
 
   const handleSubmit = useCallback(
     async (event: FormEvent) => {

--- a/src/views/SignRawDApp/SignRawDApp.tsx
+++ b/src/views/SignRawDApp/SignRawDApp.tsx
@@ -1,10 +1,14 @@
 import { FormEvent, useCallback, useRef } from 'react';
 import { browser } from 'webextension-polyfill-ts';
 import { u8aToHex } from '@polkadot/util';
+import { Crypto } from '@kiltprotocol/utils';
 
 import * as styles from './SignRawDApp.module.css';
 
-import { useIdentities } from '../../utilities/identities/identities';
+import {
+  ss58Format,
+  useIdentities,
+} from '../../utilities/identities/identities';
 import { usePopupData } from '../../utilities/popups/usePopupData';
 import { useCopyButton } from '../../components/useCopyButton/useCopyButton';
 import { Avatar } from '../../components/Avatar/Avatar';
@@ -24,7 +28,11 @@ export function SignRawDApp(): JSX.Element | null {
   const passwordField = usePasswordField();
 
   const identities = useIdentities().data;
-  const identity = identities && identities[values.address as string];
+  const kiltAddress = Crypto.encodeAddress(
+    values.address as string,
+    ss58Format,
+  );
+  const identity = identities && identities[kiltAddress];
 
   const handleSubmit = useCallback(
     async (event: FormEvent) => {


### PR DESCRIPTION
When a dApp calls Sporran API to sign something, it provides an address in any of the formats, and we cast them to the KILT format