### PR TITLE
Return credential object

### DIFF
--- a/src/channels/ASUserDataChannels/types.ts
+++ b/src/channels/ASUserDataChannels/types.ts
@@ -1,4 +1,4 @@
-import { DidUri, KiltAddress } from '@kiltprotocol/types';
+import { ICredential, KiltAddress } from '@kiltprotocol/types';
 import { HexString } from '@polkadot/util/types';
 
 import { DAppName } from '../AccessChannels/DAppName';
@@ -12,8 +12,5 @@ export type ASUserDataOriginInput = ASUserDataInput & Origin;
 
 export interface ASUserDataOutput {
   createDidExtrinsic: HexString;
-  did: DidUri;
-  firstName: string;
-  surname: string;
-  email: string;
+  credential: ICredential;
 }

--- a/src/injectedScript.ts
+++ b/src/injectedScript.ts
@@ -3,7 +3,7 @@ import {
   IEncryptedMessage,
   DidResourceUri,
   KiltAddress,
-  DidUri,
+  ICredential,
 } from '@kiltprotocol/types';
 
 import { injectedCredentialChannel } from './channels/CredentialChannels/injectedCredentialChannel';
@@ -174,10 +174,7 @@ async function getSignedDidCreationExtrinsic(submitter: KiltAddress): Promise<{
 
 async function getASUserData(submitter: KiltAddress): Promise<{
   createDidExtrinsic: HexString;
-  did: DidUri;
-  firstName: string;
-  surname: string;
-  email: string;
+  credential: ICredential;
 }> {
   const dAppName = document.title.substring(0, 50);
   return injectedASUserDataChannel.get({ dAppName, submitter });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,6 @@
 import {
   DidResourceUri,
-  DidUri,
+  ICredential,
   IEncryptedMessage,
   KiltAddress,
 } from '@kiltprotocol/types';
@@ -89,5 +89,5 @@ export interface InjectedWindowProvider<T> {
 
   getASUserData: (
     submitter: KiltAddress,
-  ) => Promise<{ createDidExtrinsic: HexString; did: DidUri; firstName: string; surname: string; email: string }>;
+  ) => Promise<{ createDidExtrinsic: HexString; credential: ICredential }>;
 }

--- a/src/views/ASUserData/ASUserData.tsx
+++ b/src/views/ASUserData/ASUserData.tsx
@@ -2,6 +2,10 @@ import { FormEvent, useCallback } from 'react';
 import { browser } from 'webextension-polyfill-ts';
 import * as Did from '@kiltprotocol/did';
 
+import { Claim, Credential } from '@kiltprotocol/core';
+
+import { ICType } from '@kiltprotocol/types';
+
 import * as styles from './ASUserData.module.css';
 
 import { ASUserDataOriginInput } from '../../channels/ASUserDataChannels/types';
@@ -17,8 +21,25 @@ import { IdentitiesCarousel } from '../../components/IdentitiesCarousel/Identiti
 
 import { backgroundASUserDataChannel } from '../../channels/ASUserDataChannels/backgroundASUserDataChannel';
 import { getIdentityCryptoFromSeed } from '../../utilities/identities/identities';
+import { saveCredential } from '../../utilities/credentials/credentials';
 
-// const ASUserCType: ICType = {};
+const axelSpringerCType: ICType = {
+  $id: 'kilt:ctype:0x62b0c9651c6eed6f38230d5e98e8fbd5d37d276e473c183af8c88933f09b3081',
+  $schema: 'http://kilt-protocol.org/draft-01/ctype#',
+  properties: {
+    Email: {
+      type: 'string',
+    },
+    'First Name': {
+      type: 'string',
+    },
+    'Last Name': {
+      type: 'string',
+    },
+  },
+  title: 'Axel Springer Login',
+  type: 'object',
+};
 
 interface Props {
   identity: Identity;
@@ -59,12 +80,30 @@ export function ASUserData({ identity }: Props): JSX.Element {
       );
       const createDidExtrinsic = storeTx.method.toHex();
 
+      const claimContents = {
+        'First Name': firstName,
+        'Last Name': surname,
+        Email: email,
+      };
+      const claim = Claim.fromCTypeAndClaimContents(
+        axelSpringerCType,
+        claimContents,
+        did,
+      );
+
+      const credential = Credential.fromClaim(claim);
+
+      await saveCredential({
+        credential,
+        name: 'AS User',
+        cTypeTitle: 'AS User',
+        attester: 'Axel Springer',
+        status: 'pending',
+      });
+
       await backgroundASUserDataChannel.return({
         createDidExtrinsic,
-        firstName,
-        did,
-        surname,
-        email,
+        credential,
       });
       window.close();
     },

--- a/src/views/ASUserData/ASUserData.tsx
+++ b/src/views/ASUserData/ASUserData.tsx
@@ -95,8 +95,8 @@ export function ASUserData({ identity }: Props): JSX.Element {
 
       await saveCredential({
         credential,
-        name: 'AS User',
-        cTypeTitle: 'AS User',
+        name: axelSpringerCType.title,
+        cTypeTitle: axelSpringerCType.title,
         attester: 'Axel Springer',
         status: 'pending',
       });


### PR DESCRIPTION
Saves the credential in the wallet in 'pending' state, returns credential object to the DApp to be attested.