### PR TITLE
chore: update rpc endpoints

### DIFF
--- a/src/utilities/checkout/checkout.ts
+++ b/src/utilities/checkout/checkout.ts
@@ -7,6 +7,7 @@ import { getEndpoint, KnownEndpoints } from '../endpoints/endpoints';
 const checkoutURLs: Record<KnownEndpoints, string> = {
   'wss://kilt-rpc.dwellir.com': 'https://checkout.kilt.io',
   'wss://spiritnet.kilt.io': 'https://checkout.kilt.io',
+  'wss://spiritnet.api.onfinality.io/public-ws': 'https://checkout.kilt.io',
   'wss://peregrine.kilt.io': 'https://dev.checkout.kilt.io',
   'wss://peregrine-stg.kilt.io/para': 'https://smoke.checkout.kilt.io',
 };

--- a/src/utilities/endpoints/endpoints.ts
+++ b/src/utilities/endpoints/endpoints.ts
@@ -7,6 +7,7 @@ const endpointKey = 'endpoints';
 
 export const endpoints = [
   'wss://kilt-rpc.dwellir.com',
+  'wss://spiritnet.api.onfinality.io/public-ws',
   'wss://spiritnet.kilt.io',
   'wss://peregrine.kilt.io',
   'wss://peregrine-stg.kilt.io/para',
@@ -15,8 +16,9 @@ export const endpoints = [
 export type KnownEndpoints = (typeof endpoints)[number];
 
 export const publicEndpoints = {
+  BOTLabs: 'wss://spiritnet.kilt.io',
   Dwellir: 'wss://kilt-rpc.dwellir.com',
-  'BOTLabs Trusted Entity': 'wss://spiritnet.kilt.io',
+  OnFinality: 'wss://spiritnet.api.onfinality.io/public-ws',
 };
 
 /* Do we already build a production version first and ask QA to test it
@@ -27,10 +29,10 @@ approach when we need to validate both endpoints, but in this case it is
 explicitly about both endpoints, so the production will be tested anyway,
 so there's no real downside. */
 
-export const defaultEndpoint =
+export const defaultEndpoint: KnownEndpoints =
   process.env.NODE_ENV === 'production' && !isInternal
-    ? endpoints[0]
-    : endpoints[2];
+    ? 'wss://kilt-rpc.dwellir.com'
+    : 'wss://peregrine.kilt.io';
 
 /**
  * Always returns a value from a known list, to be used in the mappings of an endpoint to something else

--- a/src/utilities/useSubscanHost/useSubscanHost.ts
+++ b/src/utilities/useSubscanHost/useSubscanHost.ts
@@ -5,6 +5,7 @@ const subscanHosts: Record<KnownEndpoints, string | undefined> = {
   'wss://peregrine.kilt.io': 'https://kilt-testnet.subscan.io',
   'wss://spiritnet.kilt.io': 'https://spiritnet.subscan.io',
   'wss://kilt-rpc.dwellir.com': 'https://spiritnet.subscan.io',
+  'wss://spiritnet.api.onfinality.io/public-ws': 'https://spiritnet.subscan.io',
   'wss://peregrine-stg.kilt.io/para': undefined,
 };
 

--- a/src/views/AppSettings/__snapshots__/AppSettings.test.tsx.snap
+++ b/src/views/AppSettings/__snapshots__/AppSettings.test.tsx.snap
@@ -34,6 +34,9 @@ Just start it again to continue.
           value="wss://kilt-rpc.dwellir.com"
         />
         <option
+          value="wss://spiritnet.api.onfinality.io/public-ws"
+        />
+        <option
           value="wss://spiritnet.kilt.io"
         />
         <option
@@ -49,12 +52,16 @@ Just start it again to continue.
         name="endpoint"
       >
         <option
+          label="BOTLabs"
+          value="wss://spiritnet.kilt.io"
+        />
+        <option
           label="Dwellir"
           value="wss://kilt-rpc.dwellir.com"
         />
         <option
-          label="BOTLabs Trusted Entity"
-          value="wss://spiritnet.kilt.io"
+          label="OnFinality"
+          value="wss://spiritnet.api.onfinality.io/public-ws"
         />
       </select>
       <button


### PR DESCRIPTION
fixes https://github.com/KILTprotocol/ticket/issues/3014

* RPC endpoint is not provided by the BTE but by BOTLabs
* add OnFinality RPC Endpoint
* don't use the index to specify the default endpoints
  * I added onfinality alphabetically and only noticed the indices by pure luck. 😅 
  * I specified the type `KnwonEndpoints` and add the strings explicitly. Spelling errors are less likely because the type is limited to the known URLs.