### PR TITLE
refactor: updating the transfer to allow death as new on chain logic

### DIFF
--- a/src/utilities/transfers/transfers.ts
+++ b/src/utilities/transfers/transfers.ts
@@ -20,7 +20,7 @@ export async function signTransfer(input: Input): Promise<string> {
   const { recipient, amount, keypair, tip } = input;
 
   const api = ConfigService.get('api');
-  const tx = api.tx.balances.transfer(recipient, amount);
+  const tx = api.tx.balances.transferAllowDeath(recipient, amount);
 
   const signedTx = await tx.signAsync(keypair, { tip });
   const hash = signedTx.hash.toHex();

--- a/src/views/SendToken/getFee.ts
+++ b/src/views/SendToken/getFee.ts
@@ -15,7 +15,7 @@ const fallbackAddressForFee =
 export async function getFee(input: FeeInput): Promise<BN> {
   const api = ConfigService.get('api');
 
-  const tx = api.tx.balances.transfer(
+  const tx = api.tx.balances.transferAllowDeath(
     input.recipient || fallbackAddressForFee,
     input.amount,
   );


### PR DESCRIPTION
Balances pallet now uses transfer allow death or transfer keep alive. 

We will use the allow death.