### PR TITLE
fix: downgrade manifest.js back to v2

### DIFF
--- a/src/components/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/components/Settings/__snapshots__/Settings.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`Settings menu should be visible when menu button clicked 1`] = `
             role="menuitem"
             tabindex="-1"
           >
-            Version 2024.9.10
+            Version 2024.9.11
           </a>
         </li>
       </ul>
@@ -225,7 +225,7 @@ exports[`Settings should render the endpoint item in the internal build 1`] = `
             role="menuitem"
             tabindex="-1"
           >
-            Version 2024.9.10
+            Version 2024.9.11
           </a>
         </li>
       </ul>

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -25,7 +25,7 @@ export const internalFeatures: Features = {
 
 // Duplicates the value in src/static/manifest.json
 // We can’t use browser.runtime.getManifest().version, as it’s unavailable in injected scripts
-const version = '2024.9.10';
+const version = '2024.9.11';
 
 export const configuration: ConfigurationType = {
   version,

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_manifest_name__",
   "short_name": "__MSG_manifest_short_name__",
   "description": "__MSG_manifest_description__",
-  "version": "2024.9.10",
+  "version": "2024.9.11",
   "default_locale": "en",
   "browser_action": {
     "default_icon": {

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -1,11 +1,11 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "__MSG_manifest_name__",
   "short_name": "__MSG_manifest_short_name__",
   "description": "__MSG_manifest_description__",
   "version": "2024.9.10",
   "default_locale": "en",
-  "action": {
+  "browser_action": {
     "default_icon": {
       "16": "icon/light/16.png",
       "32": "icon/light/32.png",
@@ -15,7 +15,10 @@
     "default_popup": "popup.html"
   },
   "background": {
-    "service_worker": "js/backgroundScript.js"
+    "scripts": [
+      "js/backgroundScript.js"
+    ],
+    "persistent": true
   },
   "content_scripts": [
     {
@@ -38,20 +41,8 @@
     "clipboardWrite",
     "storage"
   ],
-  "host_permissions": [
-    "*://*/*"
-  ],
-  "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
-  },
+  "content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self';",
   "web_accessible_resources": [
-    {
-      "resources": [
-        "js/injectedScript.js"
-      ],
-      "matches": [
-        "*://*/*"
-      ]
-    }
+    "js/injectedScript.js"
   ]
 }

--- a/src/views/GenericError/__snapshots__/GenericError.test.tsx.snap
+++ b/src/views/GenericError/__snapshots__/GenericError.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`GenericError should render generic error when an error happens 1`] = `
         class="details"
         readonly=""
       >
-        Sporran@2024.9.10
+        Sporran@2024.9.11
 
 Testing GenericError
 


### PR DESCRIPTION
This reverts commit bd79f2a6b036e026647433d52804691a5d1e6c6f downgrading the `manifest.js `from v3 to v2.

Upgrading the manifest to v3 requires much more than just changing the `manifest.js` file itself. We need Sporran with the newest features and fixes right away. A proper upgrade to manifest v3 can wait a bit more. 